### PR TITLE
Add title attr_accessor on Jobs

### DIFF
--- a/ext/cups.c
+++ b/ext/cups.c
@@ -109,20 +109,22 @@ static VALUE cups_print(VALUE self)
 {
   int job_id;
   VALUE file = rb_iv_get(self, "@filename");
+  VALUE rname = rb_iv_get(self, "@title");
   VALUE printer = rb_iv_get(self, "@printer");
   VALUE url_path = rb_iv_get(self, "@url_path");
 
   char *fname = RSTRING_PTR(file); // Filename
+  char *title = T_STRING == TYPE(rname) ? RSTRING_PTR(rname) : "rCups";
   char *target = RSTRING_PTR(printer); // Target printer string
   char *url = RSTRING_PTR(url_path); // Server URL address
   int port = 631; // Default CUPS port
-    
+
   VALUE job_options = rb_iv_get(self, "@job_options");
 
   // Create an array of the keys from the job_options hash
   VALUE job_options_keys = rb_ary_new();
   rb_hash_foreach(job_options, cups_keys_i, job_options_keys);
-  
+
   VALUE iter;
   int num_options = 0;
   cups_option_t *options = NULL;
@@ -520,6 +522,7 @@ void Init_cups() {
   rb_define_attr(printJobs, "url_path", 1, 0);
   rb_define_attr(printJobs, "job_id", 1, 0);
   rb_define_attr(printJobs, "job_options", 1, 0);
+  rb_define_attr(printJobs, "title", 1, 1);
 
   // Cups::PrintJob Methods
   rb_define_method(printJobs, "initialize", job_init, -1);

--- a/test/cups_test.rb
+++ b/test/cups_test.rb
@@ -110,14 +110,23 @@ class CupsTest < Test::Unit::TestCase
   def test_dest_options_raises_exception_if_not_real
     assert_raise(RuntimeError, "The printer or destination doesn't exist!") { Cups.options_for("bollocks_printer") }
   end
-  
+
   def test_job_failed_boolean
     pj = Cups::PrintJob.new(sample, @printer)
     pj.print
     pj.cancel
     assert !pj.failed?
   end
-  
+
+  def test_job_title
+      pj = Cups::PrintJob.new(sample, @printer)
+      pj.title = 'a-test-job'
+      pj.print
+      job = Cups.all_jobs(@printer)[ pj.job_id ]
+      assert_equal 'a-test-job', job[:title]
+      pj.cancel
+  end
+
   def test_returns_failure_string_on_cancellation
     pj = Cups::PrintJob.new(blank_sample, @printer)
     pj.print


### PR DESCRIPTION
The title is how print jobs are listed as in the print queue.  This allows setting it
to something useful for identifying jobs in case they need to be
paused/canceled

I'm writing a thin REST api service on top of cups and using your library to submit and list the status of jobs.  The only problem I've ran into was that all the jobs appeared in the queue as "rCups".  This should fix that.

Let me know if you'd like it reworked in some way, I'd be happy to do so.
