### PR TITLE
Clang fixes

### DIFF
--- a/ext/cups.c
+++ b/ext/cups.c
@@ -40,7 +40,7 @@ int printer_exists(VALUE printer){
   // First call Cups#show_destinations
   VALUE dest_list = rb_funcall(rubyCups, rb_intern("show_destinations"), 0);
   // Then check the printer arg is included in the returned array...
-  rb_ary_includes(dest_list, printer) ? 1 : 0;
+  return rb_ary_includes(dest_list, printer) ? 1 : 0;
 }
 
 /*


### PR DESCRIPTION
This fixes a few bugs I've encountered when running on osx and using a clang compiled Ruby.  The most surprising one was the missing return statement, I'm have no idea how/why gcc allowed that.

I've made several other changes as well:  https://github.com/nathanstitt/cups/compare/m0wfo:master...master and will be submitting pull requests for them separately.  

As always - I'll be glad to rework if you'd like something done differently.

Thanks again!
