### PR TITLE
fix passing the job title to cups

### DIFF
--- a/ext/cups.c
+++ b/ext/cups.c
@@ -153,7 +153,7 @@ static VALUE cups_print(VALUE self)
     
   int encryption = (http_encryption_t)cupsEncryption();
   http_t *http = httpConnectEncrypt (url, port, (http_encryption_t) encryption);
-  job_id = cupsPrintFile2(http, target, fname, "rCups", num_options, options); // Do it. "rCups" should be the filename/path
+  job_id = cupsPrintFile2(http, target, fname, title, num_options, options); // Do it. "rCups" should be the filename/path
   //   
   // cupsFreeOptions(num_options, options);
   


### PR DESCRIPTION
Although a title accessor was added, the actual call would still pass "rCups" hardcoded to cups. 
This fix actually passes the title that was set on the PrintJob object.
