### PR TITLE
Fix Yosemite build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+== Version 0.0.10
+2014-12-05: Build compatibility with Mac OS X 10.10 (Yosemite)
+
 == Version 0.0.7
 
 2010-11-12: PrintJob instances now take an options hash, thanks to [ransombriggs]

--- a/cups.gemspec
+++ b/cups.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{cups}
-  s.version = "0.1.9"
+  s.version = "0.1.10"
   s.authors = ["Nathan Stitt", "Tadej Murovec", "Ivan Turkovic", "Chris Mowforth"]
   s.email = ["nathan@stitt.org", "tadej.murovec@gmail.com", "me@ivanturkovic.com", "chris@mowforth.com"]
   s.summary = "A lightweight Ruby library for printing."

--- a/ext/ruby_cups.h
+++ b/ext/ruby_cups.h
@@ -1,3 +1,6 @@
+// Enable access to IPP private structures post Cups 1.5
+// (In Mac OS 10.8 thru 10.9 specifically enabled by Apple but not 10.10)
+#define _IPP_PRIVATE_STRUCTURES 1
 #include <cups/cups.h>
 
 // st.h is needed for ST_CONTINUE constant


### PR DESCRIPTION
From CUPS 1.6, the visibility of parts of the IPP data structures controlled are by the preprocessor symbol IPP_PRIVATE_STRUCTURES.
Visibility is enabled specifically for Mac OS X 10.8 and 10.9 but not for Mac OS X 10.10 in CUPS. This update forces the required visibility.
