### PR TITLE
Update README instructions to install cups

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -8,7 +8,7 @@ Print stuff in Ruby. This gem is a C wrapper for the CUPS API.
   
 To build the extensions, you need the cups library installed, and the cups-config programme in your path. On OS X you should have everything you need. On Debian/Ubuntu, running:
 
-  sudo apt-get install libcups-dev
+  sudo apt-get install libcups2-dev
 
 will set everything up.
 


### PR DESCRIPTION
In order to install cups library on Ubuntu it is necessary to perform `apt-get install libcups2-dev`.