### PR TITLE
update include st.h

### DIFF
--- a/cups.gemspec
+++ b/cups.gemspec
@@ -10,6 +10,4 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{test}/**/*") | ["ext/cups.c", "ext/ruby_cups.h", "ext/extconf.rb"] | Dir.glob("{lib}/**/*")
   s.extensions << "ext/extconf.rb"
   s.homepage = "https://github.com/m0wfo/cups"
-  s.has_rdoc = true
-  s.rubyforge_project = "cups"
 end

--- a/ext/ruby_cups.h
+++ b/ext/ruby_cups.h
@@ -2,7 +2,7 @@
 
 // st.h is needed for ST_CONTINUE constant
 #include <ruby.h>
-#include <st.h>
+#include <ruby/st.h>
 
 #ifndef MAXOPTS
   #define MAXOPTS 100


### PR DESCRIPTION
would not compile on ruby 3.0.

This fix is mentioned in #27 error log and that is reporting as ruby 2.3 so it is backward compatiable at least that far. No idea about older rubys.